### PR TITLE
Fix incorrect column mapping in BorrowDao

### DIFF
--- a/dao/BorrowDao.java
+++ b/dao/BorrowDao.java
@@ -57,25 +57,25 @@ public class BorrowDao {
         List<Borrow> borrows = new ArrayList<>();
         try (PreparedStatement ps = connection.prepareStatement(sql)) {
             ps.setInt(1, memberId);
-            ResultSet resultSet = ps.executeQuery();
+            try (ResultSet resultSet = ps.executeQuery()) {
 
-            while (resultSet.next()) {
-                int borrowId = resultSet.getInt("borrow_id");
-                int bookId = resultSet.getInt("book_id");
-                String bookTitle = resultSet.getString("book_title");
-                int authorId = resultSet.getInt("author_id");
-                String authorName = resultSet.getString("author_name");
-                String memberName = resultSet.getString("member_name");
+                while (resultSet.next()) {
+                    int borrowId = resultSet.getInt("borrow_id");
+                    int bookId = resultSet.getInt("book_id");
+                    String bookTitle = resultSet.getString("book_title");
+                    int authorId = resultSet.getInt("author_id");
+                    String authorName = resultSet.getString("author_name");
+                    String memberName = resultSet.getString("member_name");
 
-                Author author = new Author(authorId, authorName);
-                Book book = new Book(bookId, bookTitle, author);
-                Member member = new Member(memberId, memberName);
+                    Author author = new Author(authorId, authorName);
+                    Book book = new Book(bookId, bookTitle, author);
+                    Member member = new Member(memberId, memberName);
 
-                Borrow borrow = new Borrow(borrowId, member, book,
-                        resultSet.getDate("borrow_date").toLocalDate());
+                    Borrow borrow = new Borrow(borrowId, member, book,
+                            resultSet.getDate("borrow_date").toLocalDate());
 
-                borrows.add(borrow);
-
+                    borrows.add(borrow);
+                }
             }
         } catch (SQLException e) {
             e.printStackTrace();

--- a/dao/BorrowDao.java
+++ b/dao/BorrowDao.java
@@ -60,18 +60,19 @@ public class BorrowDao {
             ResultSet resultSet = ps.executeQuery();
 
             while (resultSet.next()) {
-                int borowId = resultSet.getInt(" borrow_id");
-                int bookId = resultSet.getInt(" book_id");
-                String bookTitle = resultSet.getString(" book_title ");
-                int authoId = resultSet.getInt(" author_id");
-                String authorName = resultSet.getString(" author_name");
-                String memberName = resultSet.getString(" member_name");
+                int borrowId = resultSet.getInt("borrow_id");
+                int bookId = resultSet.getInt("book_id");
+                String bookTitle = resultSet.getString("book_title");
+                int authorId = resultSet.getInt("author_id");
+                String authorName = resultSet.getString("author_name");
+                String memberName = resultSet.getString("member_name");
 
-                Author author = new Author(authoId, authorName);
+                Author author = new Author(authorId, authorName);
                 Book book = new Book(bookId, bookTitle, author);
-                Member member = new Member(memberId, "memberName");
-                Borrow borrow = new Borrow(member, book);
-                borrow.setId(borowId);
+                Member member = new Member(memberId, memberName);
+
+                Borrow borrow = new Borrow(borrowId, member, book,
+                        resultSet.getDate("borrow_date").toLocalDate());
 
                 borrows.add(borrow);
 


### PR DESCRIPTION
## Summary
- correct result set column names and data mapping in `BorrowDao#getBorrowsByMemberId`
- populate borrow objects with proper member names and borrow dates

## Testing
- `javac -d out $(find . -name "*.java")`


------
https://chatgpt.com/codex/tasks/task_e_68b9607d4d4883278a7ac3c6c667d9b0